### PR TITLE
:bug: broken links on lot reports

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -128,12 +128,12 @@ export const OPERATION_MESSAGES = {
   },
   GREEN_REPORT_CREATED: {
     MESSAGE: "Green Report Created with id ##id##",
-    BACK_LINK: "/report/list?type=green",
+    BACK_LINK: "/lot/report/list?type=green",
     BACK_TITLE: "Create more Reports",
   },
   CUPPING_REPORT_CREATED: {
     MESSAGE: "Cupping Report Created with id ##id##",
-    BACK_LINK: "/report/list?type=green",
+    BACK_LINK: "/lot/report/list?type=cupping",
     BACK_TITLE: "Create more Reports",
   },
   PAGE_EDIT: {


### PR DESCRIPTION
Resolves #5 
After creating lot report success message links were broken for both types of report