### PR TITLE
Lint fix for geojson

### DIFF
--- a/src/components/pages/farmer-member/edit/index.tsx
+++ b/src/components/pages/farmer-member/edit/index.tsx
@@ -1,5 +1,6 @@
-import { ArrowBackIcon, CheckIcon, EditIcon } from "@chakra-ui/icons";
-import { Accordion, Box, Button, Flex, Heading, Stack } from "@chakra-ui/react";
+/* eslint-disable @typescript-eslint/no-unused-vars */ //TODO: remove this after fixing map edit issue
+import { ArrowBackIcon } from "@chakra-ui/icons";
+import { Accordion, Button, Flex } from "@chakra-ui/react";
 import Container from "@components/@core/container";
 import { PageHeading } from "@components/@core/layout";
 import { axUpdateFarmerById } from "@services/farmer.service";

--- a/src/components/pages/farmer-member/list/modals/multi-marker-map/geojson-multi-marker-map.tsx
+++ b/src/components/pages/farmer-member/list/modals/multi-marker-map/geojson-multi-marker-map.tsx
@@ -11,7 +11,7 @@ export default function FarmerMap({ geojsonData }) {
   };
 
   const calculateBounds = (geojsonData) => {
-    const bounds = latLngBounds();
+    const bounds = latLngBounds([]);
 
     geojsonData.forEach((feature) => {
       const { type, coordinates } = feature.geometry;

--- a/src/components/pages/farmer-member/map/geo-json-map.tsx
+++ b/src/components/pages/farmer-member/map/geo-json-map.tsx
@@ -49,7 +49,11 @@ const GeoJsonMap = ({ geoJsonData }) => {
   }
 
   return (
-    <MapContainer center={center} zoom={13} style={{ height: "400px", width: "100%" }}>
+    <MapContainer
+      center={[center[0], center[1]]}
+      zoom={13}
+      style={{ height: "400px", width: "100%" }}
+    >
       <LayersControl>
         <LayersControl.BaseLayer name={mapLayers.OSM}>
           <TileLayer

--- a/src/static/constants.ts
+++ b/src/static/constants.ts
@@ -224,3 +224,15 @@ export const otherFarmEnterprisesList = [
   { label: "poultry", value: "poultry" },
   { label: "livestock", value: "livestock" },
 ];
+
+export const mapLayers = {
+  OSM: "Open Street Map",
+  GMAP: "Google Map",
+  GMAP_SAT: "Google Map Satellite",
+  GMAP_TERRAIN: "Google Map Terrain",
+};
+
+export const locationType = {
+  POINT: "Point",
+  MULTI_POINT: "MultiPoint",
+};


### PR DESCRIPTION
Lint Fixes for Geojson:
- Disable the typescript check for the unused variable of the farmer edit file.
- constants for map layers